### PR TITLE
Bugfix: genealogist update method

### DIFF
--- a/apps/genealogist/js/genealogist.js
+++ b/apps/genealogist/js/genealogist.js
@@ -55,7 +55,7 @@ function update(op) {
         X = $("#X").val().toLowerCase() || '_',
         Y = $("#Y").val().toLowerCase() || '_',
         command = pred + '(' + X + ',' + Y + ')';
-    Pengine({
+    pengine = new Pengine({
         application: 'genealogist',
         ask: command,
         onsuccess: function() {


### PR DESCRIPTION
Pengine object not initialized properly, causing wrong 'this' scope in Pengine constructor.
Online genealogist demo not working because of this.